### PR TITLE
chore: add group for `clap` crates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -71,6 +71,11 @@
       "matchManagers": ["cargo"],
       "matchPackagePrefixes": ["tracing"],
       "groupName": "tracing crates"
+    },
+    {
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["clap", "clap-verbosity-flag"],
+      "groupName": "clap crates"
     }
   ]
 }


### PR DESCRIPTION
We purposefully don't use a package prefix because we want to keep `clap-cargo` separate.